### PR TITLE
fix relative dramco.be URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dramco UNO
 
-LoRaWAN-enabled Arduino board developed by [DRAMCO](www.dramco.be) featuring an accelerometer and a onewire connection optimized for low-power.
+LoRaWAN-enabled Arduino board developed by [DRAMCO](https://www.dramco.be) featuring an accelerometer and a onewire connection optimized for low-power.
 
 ## Folder Structure
 


### PR DESCRIPTION
The URL to www.dramco.be is defined as a relative URL. This results in a bad link when clicking on it on Github. Changing it to an absolute URL fixes this problem.